### PR TITLE
Fix mouse handling on macOS

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,2 @@
+* Upstream different mouse handling for macOS in fenster
+  * Should set `mouse=` like the other platforms

--- a/renderer.c
+++ b/renderer.c
@@ -191,17 +191,19 @@ void r_present(void) {
   fenster_loop(&window);
 }
 
+int mouse_down = 0;
 
 int r_mouse_down(void) {
-  if (window.mouse == 1) {
-    window.mouse++;
+  if (window.mouse && !mouse_down) {
+    mouse_down = 1;
     return 1;
   }
   return 0;
 }
 
 int r_mouse_up(void) {
-  if (window.mouse < 1) {
+  if (!window.mouse && mouse_down) {
+    mouse_down = 0;
     return 1;
   }
   return 0;

--- a/renderer.h
+++ b/renderer.h
@@ -15,6 +15,7 @@ void r_clear(mu_Color color);
 void r_present(void);
 // Can only be checked once per frame; side-effecting.
  int r_mouse_down(void);
+// Can only be checked once per frame; side-effecting.
  int r_mouse_up(void);
 // Can only be checked once per frame; side-effecting.
  int r_mouse_moved(int *x, int *y);


### PR DESCRIPTION
Fenster treats mouse events differently only on macOS and until we
change that upstream, we should just handle that internally.

Thanks @g8kig for the report!

Fix #1
