### PR TITLE
Update renderer.c

### DIFF
--- a/renderer.c
+++ b/renderer.c
@@ -25,6 +25,7 @@ void r_init(void) {
   fenster_open(&window);
 
   /* init texture */
+  clip_rect = mu_rect(0, 0, window.width, window.height);
 }
 
 static inline bool within(int c, int lo, int hi) {


### PR DESCRIPTION
clip_rect must be initialized to the full window, otherwise drawing will not work until a MU_COMMAND_CLIP is issued.

This issue affects specially single-window interfaces, because there's no clipping involved.