### PR TITLE
Fixed target clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 main
 tags
 *.o
+*.exe

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,20 @@ SOURCES := main.c renderer.c microui.c
 OBJECTS := $(SOURCES:%.c=%.o)
 DEPS := $(SOURCES:%.c=%.d)
 CFLAGS += -MMD
+TARGET = native
+MAIN = main
 
-main: $(OBJECTS)
+$(MAIN): $(OBJECTS)
+	$(CC) -o $(MAIN) $(OBJECTS) $(LDLIBS)
 
 -include $(DEPS)
 
 ifeq ($(OS),Windows_NT)
+	MAIN = main.exe
+	LDLIBS += -lgdi32
+else ifeq ($(TARGET), mingw)
+	MAIN = main.exe
+	export CC = x86_64-w64-mingw32-gcc
 	LDLIBS += -lgdi32
 else
 	UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ else
 endif
 
 clean:
-	rm -f main $(OBJECTS) $(DEPS)
+	rm -f main main.exe $(OBJECTS) $(DEPS)
 
 .PHONY: clean


### PR DESCRIPTION
Also remove main.exe when building for windows (native or cross-compile).